### PR TITLE
Remove deprecated `Vararg{<:...}`

### DIFF
--- a/src/LazyStack.jl
+++ b/src/LazyStack.jl
@@ -205,7 +205,7 @@ function ChainRulesCore.rrule(::typeof(lazystack), vec::AbstractArray{<:Abstract
     lazystack(vec), Δ -> (NoTangent(), [view(Δ, ntuple(_->(:),IN)..., Tuple(I)...) for I in eachindex(vec)],)
 end
 
-function ChainRulesCore.rrule(::typeof(lazystack), tup::Tuple{Vararg{<:AbstractArray{<:Any,IN}}}) where {IN}
+function ChainRulesCore.rrule(::typeof(lazystack), tup::Tuple{Vararg{AbstractArray{<:Any,IN}}}) where {IN}
     lazystack(tup), Δ -> (NoTangent(), ntuple(i -> view(Δ, ntuple(_->(:),IN)..., i), length(tup)),)
 end
 

--- a/src/ragged.jl
+++ b/src/ragged.jl
@@ -35,7 +35,7 @@ raggedstack(x::AbstractArray, ys::AbstractArray...; kw...) = raggedstack((x, ys.
 raggedstack(g::Base.Generator; kw...) = raggedstack(collect(g); kw...)
 raggedstack(f::Function, ABC...; kw...) = raggedstack(map(f, ABC...); kw...)
 raggedstack(list::AbstractArray{<:AbstractArray}; fill=zero(eltype(first(list)))) = raggedstack_iter(list; fill)
-raggedstack(list::Tuple{Vararg{<:AbstractArray}}; fill=zero(eltype(first(list)))) = raggedstack_iter(list; fill)
+raggedstack(list::Tuple{Vararg{AbstractArray}}; fill=zero(eltype(first(list)))) = raggedstack_iter(list; fill)
 
 function raggedstack_iter(list; fill)
     T = mapreduce(eltype, Base.promote_typejoin, list, init=typeof(fill))


### PR DESCRIPTION
no functional change.