### PR TITLE
Fix Julia 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LazyStack"
 uuid = "1fad7336-0346-5a1a-a56f-a06ba010965b"
 authors = ["Michael Abbott"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/LazyStack.jl
+++ b/src/LazyStack.jl
@@ -2,10 +2,6 @@ module LazyStack
 
 export lazystack
 
-if !isdefined(Base, :LazyString)
-    const LazyString = string
-end
-
 include("ragged.jl")
 export raggedstack
 

--- a/src/LazyStack.jl
+++ b/src/LazyStack.jl
@@ -6,7 +6,7 @@ include("ragged.jl")
 export raggedstack
 
 if !isdefined(Base, :LazyString)
-    @eval const LazyString = string
+    const LazyString = string
 end
 using Compat
 

--- a/src/LazyStack.jl
+++ b/src/LazyStack.jl
@@ -2,12 +2,13 @@ module LazyStack
 
 export lazystack
 
-include("ragged.jl")
-export raggedstack
-
 if !isdefined(Base, :LazyString)
     const LazyString = string
 end
+
+include("ragged.jl")
+export raggedstack
+
 using Compat
 
 @deprecate stack lazystack false  # don't export it 

--- a/src/concatenate.jl
+++ b/src/concatenate.jl
@@ -4,6 +4,8 @@ export concatenate1, concatenate2, concatenate2!, concatenate3, concatenate3!
 
 using Base: IteratorSize, HasLength, HasShape
 
+const LazyString = isdefined(Base, :LazyString) ? Base.LazyString : string
+
 # From here, surely this can be done much better:
 # https://github.com/JuliaLang/julia/pull/46003#issuecomment-1181228513
 concatenate1(a::AbstractArray{<:AbstractArray}) = Base.hvncat(size(a), false, a...)

--- a/src/concatenate.jl
+++ b/src/concatenate.jl
@@ -2,7 +2,7 @@
 export concatenate, concatenate!
 export concatenate1, concatenate2, concatenate2!, concatenate3, concatenate3!
 
-using Base: IteratorSize, HasLength, HasShape, LazyString
+using Base: IteratorSize, HasLength, HasShape
 
 # From here, surely this can be done much better:
 # https://github.com/JuliaLang/julia/pull/46003#issuecomment-1181228513


### PR DESCRIPTION
It seems currently LazyStack is broken on Julia 1.6: https://github.com/TuringLang/MCMCDiagnosticTools.jl/actions/runs/6422465304/job/17438991939?pr=106#step:6:484

I'm away from my computer but I wonder if simply removing the `@eval` is sufficient to fix it.